### PR TITLE
Update mason version in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 dependencies:
   ansicolor: ^2.0.1
   args: ^2.4.1
-  mason: ^0.1.0-dev.49
+  mason: ^0.1.0-dev.52
   path: ^1.8.2
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 dependencies:
   ansicolor: ^2.0.1
   args: ^2.4.1
-  mason: ^0.1.0-dev.52
+  mason: 0.1.0-dev.49
   path: ^1.8.2
 
 dev_dependencies:


### PR DESCRIPTION
When an ff command is run, an error is thrown as "The current mason version is 0.1.0-dev.52. Because simple_feature requires mason version 0.1.0-dev.49, version solving failed". This is because mason version in pubspec.yml and in bricks/simple/brick.yaml do not match.